### PR TITLE
chore: update raise-deps.sh to run pnpm install when not dry running

### DIFF
--- a/.ivy/raise-deps.sh
+++ b/.ivy/raise-deps.sh
@@ -23,3 +23,8 @@ update_version() {
 for pkg in packages/*/package.json integrations/*/package.json package.json; do
   update_version "$pkg"
 done
+
+# Skip install, because transient dependencies are not available yet
+if [ "$DRY_RUN" = false ]; then
+  pnpm install --no-frozen-lockfile
+fi


### PR DESCRIPTION
Adds pnpm install call to skip-install logic in raise-deps.sh